### PR TITLE
Added preemptive note for crash on startup about DirectX runtimes.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,5 +9,9 @@ These can be rebound in the launcher.
 
 Press ESC to pause the game, then ESC again to resume or Q to exit.
 
+# Unable To Launch?
+
+Try installing the DirectX runtimes: http://www.microsoft.com/en-us/download/details.aspx?id=8109
+
 # Attributions
 Attirbutions are given in the directory the files are located in, in an attribution.md file.


### PR DESCRIPTION
Likely don't need these, but I'm not 100% sure what Unity actually needs by default and doesn't come with.
